### PR TITLE
Fix light leak of shadow #15

### DIFF
--- a/class/ShadowMapMaterial.cpp
+++ b/class/ShadowMapMaterial.cpp
@@ -75,16 +75,15 @@ std::shared_ptr<ShadowMapMaterial> ShadowMapMaterial::CreateDefaultMaterial(bool
 	VkPipelineRasterizationStateCreateInfo rasterizerCreateInfo = {};
 	rasterizerCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
 	rasterizerCreateInfo.polygonMode = VK_POLYGON_MODE_FILL;
-	rasterizerCreateInfo.cullMode = VK_CULL_MODE_FRONT_BIT;
+	rasterizerCreateInfo.cullMode = VK_CULL_MODE_BACK_BIT;
 	rasterizerCreateInfo.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
 	rasterizerCreateInfo.lineWidth = 1.0f;
 	rasterizerCreateInfo.depthClampEnable = VK_FALSE;
 	rasterizerCreateInfo.rasterizerDiscardEnable = VK_FALSE;
-	rasterizerCreateInfo.depthBiasEnable = VK_FALSE;
-	//rasterizerCreateInfo.depthBiasEnable = VK_TRUE;
-	//rasterizerCreateInfo.depthBiasConstantFactor = 1.25f;
-	//rasterizerCreateInfo.depthBiasClamp = 0.0f;
-	//rasterizerCreateInfo.depthBiasSlopeFactor = 1.75f;
+	rasterizerCreateInfo.depthBiasEnable = VK_TRUE;
+	rasterizerCreateInfo.depthBiasConstantFactor = 0;
+	rasterizerCreateInfo.depthBiasClamp = -1;
+	rasterizerCreateInfo.depthBiasSlopeFactor = -1;
 
 	VkPipelineViewportStateCreateInfo viewportStateCreateInfo = {};
 	viewportStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;


### PR DESCRIPTION
At first I though it could be peter panning. But later I recalled that I didn't use any depth bias.

Previously I use back face culling to avoid shadow acne, which works well. However, when it comes to the region where a cube intersecting with a plane, there's a little line of light leak can be observed. This is due to the nature of shadow map that one pixel in it could span a certain area in the actual scene, depending on the dot product between light and surface normal. In this case, the little light leak is certainly covered by non-shadowed light map pixel.

To fix this issue, back face culling is a perfect solution for non-thin geometries(I don't know how to get it work for thin geometries), as their front face could probably cover the intersecting area.

Fix #15 

With back face culling, we certainly need depth bias to remove shadow acne this time